### PR TITLE
对文档中的数据库配置做出完善，还有文档的UTF-8格式化编码的转换。

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/_layouts/default_cn.html
+++ b/_layouts/default_cn.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="cn">
   <head>
     <meta charset="utf-8">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 tab: docs
 ---

--- a/_layouts/docs_cn.html
+++ b/_layouts/docs_cn.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 tab: docs
 ---

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 tab: blog
 footer: hide

--- a/_layouts/post_cn.html
+++ b/_layouts/post_cn.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 tab: blog
 footer: hide

--- a/blog/_posts/2012-08-08-celebrating-50-watchers.md
+++ b/blog/_posts/2012-08-08-celebrating-50-watchers.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: post
 title: Celebrating 50 Watchers!
 author: kbengine

--- a/blog/_posts/2012-11-03-donations.md
+++ b/blog/_posts/2012-11-03-donations.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: post
 title: Donations
 author: kbengine

--- a/blog/_posts/2012-11-05-100-stargazers.md
+++ b/blog/_posts/2012-11-05-100-stargazers.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: post
 title: 100 Stargazers!
 author: kbengine

--- a/blog/_posts/2013-09-01-welcome-zachlatta.md
+++ b/blog/_posts/2013-09-01-welcome-zachlatta.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: post
 title: Welcome kbe
 author: kbengine

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 tab: blog
 footer: hide

--- a/cn/404.html
+++ b/cn/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="cn">
   <head>
     <meta charset="utf-8">

--- a/cn/blog/index.html
+++ b/cn/blog/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 tab: blog
 footer: hide

--- a/cn/demos/index.html
+++ b/cn/demos/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 title: Demos · KBEngine
 tab: demos

--- a/cn/docs/build.md
+++ b/cn/docs/build.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Build · Docs · KBEngine
 tab: docs

--- a/cn/docs/concepts/directorys.md
+++ b/cn/docs/concepts/directorys.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Server Layout · Docs · KBE
 tab: docs

--- a/cn/docs/concepts/layout.md
+++ b/cn/docs/concepts/layout.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Server Layout · Docs · KBE
 tab: docs

--- a/cn/docs/configuration/email_service.md
+++ b/cn/docs/configuration/email_service.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/entities.md
+++ b/cn/docs/configuration/entities.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Entities · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/kbengine.md
+++ b/cn/docs/configuration/kbengine.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/kbengine_defs.md
+++ b/cn/docs/configuration/kbengine_defs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Server Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/log4cxx_properties.md
+++ b/cn/docs/configuration/log4cxx_properties.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/messages_fixed.md
+++ b/cn/docs/configuration/messages_fixed.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/configuration/server_errors.md
+++ b/cn/docs/configuration/server_errors.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/getlogs.md
+++ b/cn/docs/documentations/getlogs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Get the runtime logs · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview.md
+++ b/cn/docs/documentations/kbengine_overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: KBEngine Overview · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/baseapp.md
+++ b/cn/docs/documentations/kbengine_overview/baseapp.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Baseapp · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/baseappmgr.md
+++ b/cn/docs/documentations/kbengine_overview/baseappmgr.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: BaseappMgr · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/cellapp.md
+++ b/cn/docs/documentations/kbengine_overview/cellapp.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Cellapp · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/cellappmgr.md
+++ b/cn/docs/documentations/kbengine_overview/cellappmgr.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: CellappMgr · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/dbmgr.md
+++ b/cn/docs/documentations/kbengine_overview/dbmgr.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: DBMgr · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/interfaces.md
+++ b/cn/docs/documentations/kbengine_overview/interfaces.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Interfaces · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/logger.md
+++ b/cn/docs/documentations/kbengine_overview/logger.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Logger · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/loginapp.md
+++ b/cn/docs/documentations/kbengine_overview/loginapp.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Loginapp · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/machine.md
+++ b/cn/docs/documentations/kbengine_overview/machine.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Machine · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/kbengine_overview/overview.md
+++ b/cn/docs/documentations/kbengine_overview/overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: KBEngine Overview · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/linuxfirewall.md
+++ b/cn/docs/documentations/linuxfirewall.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Linux firewall settings · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/linuxosconfig.md
+++ b/cn/docs/documentations/linuxosconfig.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: High-performance linux server configuration · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/minimum_project.md
+++ b/cn/docs/documentations/minimum_project.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Minimum Project · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/onlinedebugging.md
+++ b/cn/docs/documentations/onlinedebugging.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Online debugging · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/roomgameexample.md
+++ b/cn/docs/documentations/roomgameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: The room games · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/rpggameexample.md
+++ b/cn/docs/documentations/rpggameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Multiplayer online RPG · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/rtsgameexample.md
+++ b/cn/docs/documentations/rtsgameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: RTS game · Docs · KBEngine
 tab: docs

--- a/cn/docs/documentations/stresstest.md
+++ b/cn/docs/documentations/stresstest.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Stress Test · Docs · KBEngine
 tab: docs

--- a/cn/docs/faq.md
+++ b/cn/docs/faq.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: FAQ · Docs · KBEngine
 tab: docs

--- a/cn/docs/index.html
+++ b/cn/docs/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Docs · KBEngine
 tab: docs

--- a/cn/docs/installation.md
+++ b/cn/docs/installation.md
@@ -141,10 +141,10 @@ KBEngine会读取系统中设置的(KBE_ROOT, KBE_RES_PATH, KBE_BIN_PATH)环境�
 		下载并安装最新版本:
 		http://dev.mysql.com/downloads/windows/
 
-		Windows环境，Mysql默认是忽略大小写的，请在my.ini添加如下命令设置大小写敏感
-		在命令行使用(sc qc MySQL|find ".ini")查看my.ini文件所在目录
-        如果没有发现my.ini文件，而是发现了my-default.ini文件，对my-default.ini文件复制一份，
-        重命名为my.ini文件，在拷贝好的my.ini文件中操作。
+		Windows环境，Mysql默认是忽略大小写的，请在my.ini添加如下命令设置大小写敏感。
+		在命令行使用(sc qc MySQL|find ".ini")查看my.ini文件所在目录。
+		如果没有发现my.ini文件，而是发现了my-default.ini文件，对my-default.ini文件复制一份，
+		重命名为my.ini文件，在拷贝好的my.ini文件中操作。
 
 		[mysqld]
 		lower_case_table_names = 0

--- a/cn/docs/installation.md
+++ b/cn/docs/installation.md
@@ -143,6 +143,7 @@ KBEngine会读取系统中设置的(KBE_ROOT, KBE_RES_PATH, KBE_BIN_PATH)环境�
 
 		Windows环境，Mysql默认是忽略大小写的，请在my.ini添加如下命令设置大小写敏感
 		在命令行使用(sc qc MySQL|find ".ini")查看my.ini文件所在目录
+        如果没有发现my.ini文件，而是发现了my-default.ini文件，对my-default.ini文件复制一份，重命名为my.ini文件，在拷贝好的my.ini文件中操作。
 
 		[mysqld]
 		lower_case_table_names = 0

--- a/cn/docs/installation.md
+++ b/cn/docs/installation.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Installation · Docs · KBEngine
 tab: docs
@@ -143,7 +143,8 @@ KBEngine会读取系统中设置的(KBE_ROOT, KBE_RES_PATH, KBE_BIN_PATH)环境�
 
 		Windows环境，Mysql默认是忽略大小写的，请在my.ini添加如下命令设置大小写敏感
 		在命令行使用(sc qc MySQL|find ".ini")查看my.ini文件所在目录
-        如果没有发现my.ini文件，而是发现了my-default.ini文件，对my-default.ini文件复制一份，重命名为my.ini文件，在拷贝好的my.ini文件中操作。
+        如果没有发现my.ini文件，而是发现了my-default.ini文件，对my-default.ini文件复制一份，
+        重命名为my.ini文件，在拷贝好的my.ini文件中操作。
 
 		[mysqld]
 		lower_case_table_names = 0

--- a/cn/docs/programming/alias.md
+++ b/cn/docs/programming/alias.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Type the alias · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/apidocs.md
+++ b/cn/docs/programming/apidocs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: API Docs · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/clientsdkprogramming.md
+++ b/cn/docs/programming/clientsdkprogramming.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Script Programming · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/customtypes.md
+++ b/cn/docs/programming/customtypes.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Custom types · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/entitydef.md
+++ b/cn/docs/programming/entitydef.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Defining the Entity · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/kbe_message_format.md
+++ b/cn/docs/programming/kbe_message_format.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Communication protocol format · Docs · KBEngine
 tab: docs

--- a/cn/docs/programming/serverengineprogramming.md
+++ b/cn/docs/programming/serverengineprogramming.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Server Engine Programming · Docs · KBEngine
 tab: docs

--- a/cn/docs/startup_shutdown.md
+++ b/cn/docs/startup_shutdown.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Startup and Shutdown · Docs · KBEngine
 tab: docs

--- a/cn/docs/tools/guiconsole.md
+++ b/cn/docs/tools/guiconsole.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Guiconsole Tools · Docs · KBEngine
 tab: docs

--- a/cn/docs/tools/index.md
+++ b/cn/docs/tools/index.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Tools Overview · Docs · KBEngine
 tab: docs

--- a/cn/docs/tools/installer.md
+++ b/cn/docs/tools/installer.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Installer · Docs · KBEngine
 tab: docs

--- a/cn/docs/tools/pycluster.md
+++ b/cn/docs/tools/pycluster.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Pycluster Tools · Docs · KBEngine
 tab: docs

--- a/cn/docs/uninstallation.md
+++ b/cn/docs/uninstallation.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Uninstallation · Docs · KBEngine
 tab: docs

--- a/cn/docs/updating.md
+++ b/cn/docs/updating.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs_cn
 title: Updating · Docs · KBEngine
 tab: docs

--- a/cn/forum/index.html
+++ b/cn/forum/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 tab: forum
 footer: hide

--- a/cn/index.html
+++ b/cn/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 title: KBEngine
 tab: overview

--- a/cn/screenshots/index.html
+++ b/cn/screenshots/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default_cn
 tab: screenshots
 footer: hide

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 title: Demos · KBEngine
 tab: demos

--- a/demotest/Assets.html
+++ b/demotest/Assets.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/demotest/index.html
+++ b/demotest/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Build · Docs · KBEngine
 tab: docs

--- a/docs/concepts/directorys.md
+++ b/docs/concepts/directorys.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Server Layout · Docs · KBE
 tab: docs

--- a/docs/concepts/layout.md
+++ b/docs/concepts/layout.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Server Layout · Docs · KBE
 tab: docs

--- a/docs/configuration/email_service.md
+++ b/docs/configuration/email_service.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/docs/configuration/entities.md
+++ b/docs/configuration/entities.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Entities · Docs · KBEngine
 tab: docs

--- a/docs/configuration/kbengine.md
+++ b/docs/configuration/kbengine.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/docs/configuration/kbengine_defs.md
+++ b/docs/configuration/kbengine_defs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Server Configuration · Docs · KBEngine
 tab: docs

--- a/docs/configuration/log4cxx_properties.md
+++ b/docs/configuration/log4cxx_properties.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/docs/configuration/messages_fixed.md
+++ b/docs/configuration/messages_fixed.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/docs/configuration/server_errors.md
+++ b/docs/configuration/server_errors.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Global Configuration · Docs · KBEngine
 tab: docs

--- a/docs/documentations/getlogs.md
+++ b/docs/documentations/getlogs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Get the runtime logs · Docs · KBEngine
 tab: docs

--- a/docs/documentations/kbengine_overview.md
+++ b/docs/documentations/kbengine_overview.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: KBEngine Overview · Docs · KBEngine
 tab: docs

--- a/docs/documentations/linuxfirewall.md
+++ b/docs/documentations/linuxfirewall.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Linux firewall settings · Docs · KBEngine
 tab: docs

--- a/docs/documentations/linuxosconfig.md
+++ b/docs/documentations/linuxosconfig.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: High-performance linux server configuration · Docs · KBEngine
 tab: docs

--- a/docs/documentations/minimum_project.md
+++ b/docs/documentations/minimum_project.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Minimum Project · Docs · KBEngine
 tab: docs

--- a/docs/documentations/onlinedebugging.md
+++ b/docs/documentations/onlinedebugging.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Online debugging · Docs · KBEngine
 tab: docs

--- a/docs/documentations/roomgameexample.md
+++ b/docs/documentations/roomgameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: The room games · Docs · KBEngine
 tab: docs

--- a/docs/documentations/rpggameexample.md
+++ b/docs/documentations/rpggameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Multiplayer online RPG · Docs · KBEngine
 tab: docs

--- a/docs/documentations/rtsgameexample.md
+++ b/docs/documentations/rtsgameexample.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: RTS game · Docs · KBEngine
 tab: docs

--- a/docs/documentations/stresstest.md
+++ b/docs/documentations/stresstest.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Stress Test · Docs · KBEngine
 tab: docs

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: FAQ · Docs · KBEngine
 tab: docs

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Docs · KBEngine
 tab: docs

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Installation · Docs · KBEngine
 tab: docs

--- a/docs/programming/alias.md
+++ b/docs/programming/alias.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Type the alias · Docs · KBEngine
 tab: docs

--- a/docs/programming/apidocs.md
+++ b/docs/programming/apidocs.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: API Docs · Docs · KBEngine
 tab: docs

--- a/docs/programming/clientsdkprogramming.md
+++ b/docs/programming/clientsdkprogramming.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Script Programming · Docs · KBEngine
 tab: docs

--- a/docs/programming/customtypes.md
+++ b/docs/programming/customtypes.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Custom types · Docs · KBEngine
 tab: docs

--- a/docs/programming/entitydef.md
+++ b/docs/programming/entitydef.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Defining the Entity · Docs · KBEngine
 tab: docs

--- a/docs/programming/kbe_message_format.md
+++ b/docs/programming/kbe_message_format.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Communication protocol format · Docs · KBEngine
 tab: docs

--- a/docs/programming/serverengineprogramming.md
+++ b/docs/programming/serverengineprogramming.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Server Engine Programming · Docs · KBEngine
 tab: docs

--- a/docs/startup_shutdown.md
+++ b/docs/startup_shutdown.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Startup and Shutdown · Docs · KBEngine
 tab: docs

--- a/docs/tools/guiconsole.md
+++ b/docs/tools/guiconsole.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Guiconsole Tools · Docs · KBEngine
 tab: docs

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Tools Overview · Docs · KBEngine
 tab: docs

--- a/docs/tools/installer.md
+++ b/docs/tools/installer.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Installer · Docs · KBEngine
 tab: docs

--- a/docs/tools/pycluster.md
+++ b/docs/tools/pycluster.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Pycluster Tools · Docs · KBEngine
 tab: docs

--- a/docs/uninstallation.md
+++ b/docs/uninstallation.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Uninstallation · Docs · KBEngine
 tab: docs

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,4 +1,4 @@
----
+﻿---
 layout: docs
 title: Updating · Docs · KBEngine
 tab: docs

--- a/forum/index.html
+++ b/forum/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 tab: forum
 footer: hide

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 title: KBEngine
 tab: overview

--- a/screenshots/index.html
+++ b/screenshots/index.html
@@ -1,4 +1,4 @@
----
+﻿---
 layout: default
 tab: screenshots
 footer: hide


### PR DESCRIPTION
01.
很多同学对mysql不熟悉，用zip形式mysql安装之后，发现没有my.ini文件，而是有my-default.ini文件，不知道如何操作下去，所以对文档的这一步进行说明。

![001](https://cloud.githubusercontent.com/assets/12136292/8022550/354b0da0-0d0b-11e5-8ccf-0c68a9763617.jpg)

02.
发现文档的中html文件和md文件是用utf-8无bom格式编码保存的，这样会导致在浏览器打开下载好的文档，浏览时容易出现乱码问题，用某些文本编辑器打开时也容易出现乱码，英文文档不会出现这个问题，中文文档会出现这个问题。因为浏览器无法识别文件的具体编码，需要用户手动选择编码类型。

截图
2-1 原文档的中html文件和md文件是用utf-8无bom格式编码保存的。
![02](https://cloud.githubusercontent.com/assets/12136292/8022575/0d223186-0d0c-11e5-92e6-45421db721e5.jpg)



2-2 对文件的html和md文件保存为utf-8格式编码之后，浏览器对下载好的文件无需用户自行选择编码，直接可以浏览。

![03](https://cloud.githubusercontent.com/assets/12136292/8022576/243b59a6-0d0c-11e5-938d-42e6edd728a0.jpg)





