### PR TITLE
从页面展示无误的版本修改，没有任何格式转换

### DIFF
--- a/cn/docs/installation.md
+++ b/cn/docs/installation.md
@@ -141,8 +141,8 @@ KBEngine会读取系统中设置的(KBE_ROOT, KBE_RES_PATH, KBE_BIN_PATH)环境�
 		下载并安装最新版本:
 		http://dev.mysql.com/downloads/windows/
 
-		Windows环境，Mysql默认是忽略大小写的，请在my.ini添加如下命令设置大小写敏感
-		在命令行使用(sc qc MySQL|find ".ini")查看my.ini文件所在目录
+		Windows环境，Mysql默认是忽略大小写的，请在my.ini(一些版本可能叫my-default.ini)添加如下命令设置大小写敏感。
+		在命令行使用(sc qc MySQL|find ".ini")查看*.ini配置文件所在目录。
 
 		[mysqld]
 		lower_case_table_names = 0


### PR DESCRIPTION
从页面展示无误的版本修改，my.ini文字使用kbe写的，没有任何格式转换，合并之后可以检查页面效果。
![04-02](https://cloud.githubusercontent.com/assets/12136292/8033974/ec6b4882-0e15-11e5-9ea9-bb832a8e0592.jpg)







