### PR TITLE
调整导航栏及里程碑内容块的间距

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,10 +45,6 @@ li {
   height: 80px;
 }
 
-.container {
-	margin-top: 2em;
-}
-
 .section h1,
 .section .byline {
   text-align: center;
@@ -199,8 +195,7 @@ li {
 }
 
 .milestones {
-  /*border-top: 1px solid #e5e5e5;*/
-  /*padding-top: 50px;*/
+  padding-top: 50px;
   display: none;
 }
 .milestones h1 {


### PR DESCRIPTION
@kbengine

**修改前**

- 导航栏受到 container 样式的影响，产生了多余的间距。
- 里程碑内容块中，标题与上边框贴得太紧。

![qq 20170707195403](https://user-images.githubusercontent.com/1730073/27957231-22683c92-6350-11e7-8f94-f8098137208a.png)

![qq 20170707195440](https://user-images.githubusercontent.com/1730073/27957232-22868918-6350-11e7-92b6-a0a165052160.png)

![qq 20170707200330](https://user-images.githubusercontent.com/1730073/27957233-23342cee-6350-11e7-96c4-ddcc253e2e49.png)

**修改后**

![qq 20170707201252](https://user-images.githubusercontent.com/1730073/27957346-b04e4556-6350-11e7-9a5c-2c71e733ea84.png)

![qq 20170707201555](https://user-images.githubusercontent.com/1730073/27957433-1c783642-6351-11e7-94f0-b4d3f37a2209.png)


